### PR TITLE
feat: warm Anthropic-style UI, stronger pane hierarchy

### DIFF
--- a/src/components/session-detail.tsx
+++ b/src/components/session-detail.tsx
@@ -125,11 +125,21 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
   return (
     <div className="flex h-full flex-col">
       <div
-        className="border-b px-5 py-4"
-        style={{ borderColor: "var(--border)", background: "var(--surface-2)" }}
+        className="px-5 py-4"
+        style={{ background: "var(--surface-2)" }}
       >
         <div className="mb-2 flex items-start justify-between gap-4">
-          <h2 className="text-lg font-semibold leading-tight">{title}</h2>
+          <h2
+            className="leading-tight"
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: "20px",
+              fontWeight: 500,
+              letterSpacing: "-0.005em",
+            }}
+          >
+            {title}
+          </h2>
           <div className="flex shrink-0 gap-2">
             <button
               onClick={onCopyResume}
@@ -201,11 +211,15 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
         )}
       </div>
 
-      <div
-        className="border-b px-5 py-4"
-        style={{ borderColor: "var(--border)" }}
-      >
-        <div className="mb-1 text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+      <div className="px-5 pt-4 pb-3">
+        <div
+          className="mb-1.5 font-semibold uppercase tracking-[0.08em]"
+          style={{
+            color: "var(--text-muted)",
+            opacity: 0.85,
+            fontSize: "10.5px",
+          }}
+        >
           TLDR
         </div>
         <p className="whitespace-pre-wrap text-sm">{heuristicTldr(session)}</p>
@@ -254,10 +268,7 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
         </div>
       </div>
 
-      <div
-        className="grid grid-cols-2 gap-4 border-b px-5 py-4 text-xs md:grid-cols-4"
-        style={{ borderColor: "var(--border)" }}
-      >
+      <div className="grid grid-cols-2 gap-2 px-5 py-3 text-xs md:grid-cols-4">
         <Metric label="Messages" value={formatNumber(session.message_count)} />
         <Metric
           label="Tokens (total)"
@@ -272,13 +283,14 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
       </div>
 
       {toolEntries.length > 0 && (
-        <div
-          className="border-b px-5 py-3"
-          style={{ borderColor: "var(--border)" }}
-        >
+        <div className="px-5 py-3">
           <div
-            className="mb-2 text-xs font-semibold uppercase tracking-wide"
-            style={{ color: "var(--text-muted)" }}
+            className="mb-2 font-semibold uppercase tracking-[0.08em]"
+            style={{
+              color: "var(--text-muted)",
+              opacity: 0.85,
+              fontSize: "10.5px",
+            }}
           >
             Tool calls
           </div>
@@ -288,8 +300,8 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
                 key={name}
                 className="rounded-full px-2 py-0.5 text-xs"
                 style={{
-                  background: "var(--surface-3)",
-                  color: "var(--text)",
+                  background: "var(--accent-soft)",
+                  color: "var(--accent)",
                 }}
               >
                 {name} ·{" "}
@@ -301,11 +313,15 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
       )}
 
       {session.files_touched.length > 0 && (
-        <details
-          className="border-b px-5 py-3"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wide" style={{ color: "var(--text-muted)" }}>
+        <details className="px-5 py-3">
+          <summary
+            className="cursor-pointer font-semibold uppercase tracking-[0.08em]"
+            style={{
+              color: "var(--text-muted)",
+              opacity: 0.85,
+              fontSize: "10.5px",
+            }}
+          >
             Files touched ({session.files_touched.length})
           </summary>
           <ul className="mt-2 space-y-0.5 font-mono text-xs" style={{ color: "var(--text-muted)" }}>
@@ -335,17 +351,27 @@ function Metric({
   sub?: string;
 }) {
   return (
-    <div>
+    <div
+      className="rounded-lg border px-3 py-2.5"
+      style={{
+        background: "var(--surface-2)",
+        borderColor: "var(--border)",
+      }}
+    >
       <div
-        className="text-[10px] font-semibold uppercase tracking-wide"
-        style={{ color: "var(--text-muted)" }}
+        className="font-semibold uppercase tracking-[0.08em]"
+        style={{
+          color: "var(--text-muted)",
+          opacity: 0.85,
+          fontSize: "10px",
+        }}
       >
         {label}
       </div>
-      <div className="mt-0.5 text-sm font-medium">{value}</div>
+      <div className="mt-1 text-base font-medium leading-tight">{value}</div>
       {sub && (
         <div
-          className="text-[11px]"
+          className="mt-0.5 text-[11px]"
           style={{ color: "var(--text-muted)" }}
         >
           {sub}

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -21,12 +21,27 @@ interface Props {
   loading: boolean;
 }
 
+function stripCaveat(raw: string): string {
+  // Claude Code injects a <local-command-caveat>Caveat: The messages below…</local-command-caveat>
+  // wrapper ahead of the real prompt. Strip it (and any whitespace) so the
+  // visible title is the user's actual first sentence.
+  let s = raw.replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/gi, "").trim();
+  // Some sessions leave a bare "Caveat: …" paragraph with no tags.
+  if (/^caveat:/i.test(s)) {
+    const nl = s.indexOf("\n");
+    s = nl === -1 ? "" : s.slice(nl + 1).trim();
+  }
+  return s;
+}
+
 function titleFor(s: SessionRow): string {
   if (s.custom_title) return s.custom_title;
-  const msg = s.first_user_msg?.trim();
-  if (msg) {
-    const firstLine = msg.split("\n")[0];
-    return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine;
+  const cleaned = stripCaveat(s.first_user_msg ?? "");
+  if (cleaned) {
+    const firstLine = cleaned.split("\n").find((l) => l.trim().length > 0) ?? "";
+    if (firstLine) {
+      return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine;
+    }
   }
   return `Session ${s.session_id.slice(0, 8)}`;
 }
@@ -54,7 +69,7 @@ export function SessionList(props: Props) {
 
   return (
     <div className="flex h-full flex-col border-r" style={{ borderColor: "var(--border)" }}>
-      <div className="p-3 space-y-2 border-b" style={{ borderColor: "var(--border)", background: "var(--surface-2)" }}>
+      <div className="p-3 space-y-2" style={{ background: "var(--surface-2)" }}>
         <input
           type="text"
           placeholder="Search conversations…"
@@ -117,13 +132,19 @@ export function SessionList(props: Props) {
           </div>
         )}
         {grouped.map(([project, rows]) => (
-          <div key={project}>
+          <div key={project} className="pb-2">
             <div
-              className="px-3 py-2 text-xs font-medium uppercase tracking-wide"
-              style={{ color: "var(--text-muted)", background: "var(--surface-2)" }}
+              className="sticky top-0 z-10 px-3 pb-1.5 pt-3 text-[10.5px] font-semibold uppercase tracking-[0.08em]"
+              style={{
+                color: "var(--accent)",
+                background: "var(--surface-2)",
+                borderBottom: "1px solid var(--border)",
+              }}
             >
               {shortProject(project)}{" "}
-              <span style={{ opacity: 0.6 }}>· {rows.length}</span>
+              <span style={{ color: "var(--text-muted)", opacity: 0.8 }}>
+                · {rows.length}
+              </span>
             </div>
             {rows.map((s) => {
               const title = titleFor(s);
@@ -136,32 +157,40 @@ export function SessionList(props: Props) {
                   data-session-id={s.session_id}
                   onClick={() => props.onSelect(s.session_id)}
                   className={cn(
-                    "block w-full text-left px-3 py-2 text-sm border-b",
-                    "hover:bg-[var(--surface-2)]",
-                    isSelected && "bg-[var(--surface-3)]"
+                    "block w-full text-left pr-3 py-2 text-sm",
+                    "transition-colors",
+                    !isSelected && "hover:bg-[var(--surface-2)]"
                   )}
-                  style={{ borderColor: "var(--border)" }}
+                  style={{
+                    paddingLeft: "20px",
+                    borderLeft: `2px solid ${isSelected ? "var(--accent)" : "transparent"}`,
+                    background: isSelected ? "var(--accent-soft)" : "transparent",
+                  }}
                 >
-                  <div className="truncate font-medium" title={title}>
+                  <div
+                    className="truncate font-medium"
+                    style={{ fontSize: "14px" }}
+                    title={title}
+                  >
                     {title}
                   </div>
                   {s.snippet && (
                     <div
-                      className="truncate text-xs mt-0.5"
-                      style={{ color: "var(--text-muted)" }}
+                      className="truncate mt-1"
+                      style={{ color: "var(--text-muted)", fontSize: "12px" }}
                       dangerouslySetInnerHTML={{ __html: sanitizeSnippet(s.snippet) }}
                     />
                   )}
                   <div
-                    className="mt-1 flex items-center gap-2 text-xs"
-                    style={{ color: "var(--text-muted)" }}
+                    className="mt-1 flex items-center gap-2"
+                    style={{ color: "var(--text-muted)", fontSize: "11px" }}
                   >
                     <span>{formatRelative(s.ended_at_ms || s.started_at_ms)}</span>
-                    <span>·</span>
+                    <span aria-hidden="true">·</span>
                     <span>{s.message_count} msgs</span>
                     {uniqueModels.length > 0 && (
                       <>
-                        <span>·</span>
+                        <span aria-hidden="true">·</span>
                         {uniqueModels.map((m) => (
                           <span
                             key={m}

--- a/src/components/transcript.tsx
+++ b/src/components/transcript.tsx
@@ -15,9 +15,8 @@ function TurnCard({ turn }: { turn: Turn }) {
 
   return (
     <div
-      className="px-4 py-3 border-b"
+      className="px-5 py-4"
       style={{
-        borderColor: "var(--border)",
         background: isUser ? "var(--surface-2)" : "var(--surface)",
       }}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -4,15 +4,17 @@
 
 :root {
   color-scheme: light dark;
-  --surface: #ffffff;
-  --surface-2: #f6f7f9;
-  --surface-3: #eef0f3;
-  --border: #e4e6ea;
-  --text: #0f1115;
-  --text-muted: #5e6772;
-  --accent: #6366f1;
-  --mark: #fde68a;
-  --danger: #dc2626;
+  --surface: #faf9f5;
+  --surface-2: #f0eee6;
+  --surface-3: #e8e6dc;
+  --border: #e0ddd1;
+  --text: #1f1e1d;
+  --text-muted: #6b6a62;
+  --accent: #cc785c;
+  --accent-soft: #f5e8e0;
+  --mark: #f5e8b8;
+  --danger: #c4453c;
+  --font-serif: ui-serif, Georgia, "Tiempos Text", "Times New Roman", serif;
   font-family:
     ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
@@ -20,15 +22,16 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --surface: #0f1115;
-    --surface-2: #161921;
-    --surface-3: #1f232d;
-    --border: #2a2f3a;
-    --text: #e6e8ec;
-    --text-muted: #8b95a4;
-    --accent: #818cf8;
-    --mark: #78350f;
-    --danger: #f87171;
+    --surface: #1f1e1d;
+    --surface-2: #262624;
+    --surface-3: #30302e;
+    --border: #3a3836;
+    --text: #f5f4ed;
+    --text-muted: #a8a69c;
+    --accent: #da7756;
+    --accent-soft: #3a2a22;
+    --mark: #5a4a1f;
+    --danger: #e07b70;
   }
 }
 
@@ -41,7 +44,7 @@ body,
   background: var(--surface);
   color: var(--text);
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.55;
   -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
## Summary

Closes #3. Pure styling/markup pass — no data model, IPC, or Rust changes.

- **Repainted design tokens** (`src/index.css`) from cold slate + indigo to warm ivory/charcoal + Claude Clay coral (`#CC785C` / `#DA7756`). New `--accent-soft` tint and `--font-serif` variable; body line-height bumped to 1.55.
- **Left pane redesigned** (`src/components/session-list.tsx`): sticky uppercase coral project headers with a hairline; session rows indented to 20px; 2px coral left-rule + `--accent-soft` background on selection; `titleFor()` now strips `<local-command-caveat>` wrappers so the visible title is the user's actual prompt.
- **Detail pane warmed up** (`src/components/session-detail.tsx`): title in serif at 20px/500; metrics promoted from a flat grid to soft cards (`--surface-2`, rounded, hairline border); tool-call chips switched to coral-tinted (`--accent-soft` + `--accent`); section headers dropped to 10.5px at 0.85 opacity for an editorial feel.
- **Reduced visual noise**: removed full-width `border-b` dividers between detail-pane sections and between every transcript turn (`src/components/transcript.tsx`). Alternating surface fills and card containers handle the separation now.

## Test plan

- [ ] `bun run tauri dev` launches without errors.
- [ ] Sidebar project headers are unmistakable at a glance (coral uppercase label + hairline, no row background).
- [ ] Session rows are visibly indented under their headers; selected session shows coral left-rule + tinted background.
- [ ] Click a session whose first user message starts with `<local-command-caveat>` — the wrapper is stripped and the real prompt shows.
- [ ] Toggle macOS appearance light ↔ dark — both modes feel warm, not cold-slate or naïve-white.
- [ ] Detail pane: serif title, four metric cards grouped, coral "Copy resume cmd" button, coral-tinted tool chips, no hairlines between sections or transcript turns.
- [ ] Search term highlight (`<mark>`) still reads against the new palette.
- [ ] `bun run tsc --noEmit` and `bun run vite build` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)