### PR TITLE
feat: sort session list by date, project, messages, or cost

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -57,6 +57,31 @@ pub struct ListArgs {
     pub started_before_ms: Option<i64>,
     #[serde(default)]
     pub limit: Option<u32>,
+    #[serde(default)]
+    pub sort_by: Option<String>,
+}
+
+/// Map a UI sort key to a safe ORDER BY fragment. When a search query is
+/// active and the user hasn't picked an explicit sort, fall back to bm25
+/// relevance so typing still surfaces the best matches first. Every other
+/// sort gets `started_at_ms DESC` as a stable tiebreaker — that column is
+/// indexed, so the tiebreaker is free. Returns a `&'static str`, which makes
+/// concatenation into dynamic SQL injection-safe.
+fn order_clause(sort_by: Option<&str>, has_query: bool) -> &'static str {
+    match sort_by.unwrap_or("newest") {
+        "oldest" => "started_at_ms ASC",
+        "modified" => "ended_at_ms DESC, started_at_ms DESC",
+        "project" => "project_dir ASC, started_at_ms DESC",
+        "messages" => "message_count DESC, started_at_ms DESC",
+        "cost" => "estimated_cost_usd DESC, started_at_ms DESC",
+        _ => {
+            if has_query {
+                "bm25(sessions_fts, 10.0, 8.0, 6.0, 5.0, 1.0)"
+            } else {
+                "started_at_ms DESC"
+            }
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -137,6 +162,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
     if has_query {
         let raw = args.query.unwrap();
         let match_expr = build_match_expression(&raw);
+        let order_by = order_clause(args.sort_by.as_deref(), true);
 
         let sql = format!(
             r#"
@@ -156,7 +182,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                   {model_filter}
                   {started_after}
                   {started_before}
-            ORDER BY bm25(sessions_fts, 10.0, 8.0, 6.0, 5.0, 1.0)
+            ORDER BY {order_by}
             LIMIT ?2
             "#,
             proj_filter = if args.project_dir.is_some() { "AND s.project_dir = ?3" } else { "" },
@@ -165,6 +191,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
             } else { "" },
             started_after = "",
             started_before = "",
+            order_by = order_by,
         );
 
         let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
@@ -220,6 +247,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
 
         params_vec.push(SqlValue::Integer(limit));
         let limit_idx = params_vec.len();
+        let order_by = order_clause(args.sort_by.as_deref(), false);
 
         let sql = format!(
             r#"
@@ -233,7 +261,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                    claude_version, pinned_at
             FROM sessions
             {where_clause}
-            ORDER BY started_at_ms DESC
+            ORDER BY {order_by}
             LIMIT ?{limit_idx}
             "#
         );
@@ -330,6 +358,7 @@ pub fn get_session(
         started_after_ms: None,
         started_before_ms: None,
         limit: Some(500),
+        sort_by: None,
     };
     // Reuse list with a direct ID filter — cheaper to write a targeted query.
     drop(args);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   listProjects,
   listSessions,
   type SessionRow,
+  type SortKey,
 } from "@/lib/ipc";
 import { SessionList } from "@/components/session-list";
 import { SessionDetail } from "@/components/session-detail";
@@ -20,6 +21,7 @@ export default function App() {
   const [query, setQuery] = useState("");
   const [projectFilter, setProjectFilter] = useState<string | null>(null);
   const [modelFilter, setModelFilter] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortKey>("newest");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [pinnedSessions, setPinnedSessions] = useState<SessionRow[]>([]);
   const [projects, setProjects] = useState<Array<[string, number]>>([]);
@@ -60,13 +62,14 @@ export default function App() {
         query: query.trim() || undefined,
         projectDir: projectFilter ?? undefined,
         modelContains: modelFilter ?? undefined,
+        sortBy,
       });
       if (reqIdRef.current !== reqId) return;
       setSessions(rows);
     } finally {
       if (reqIdRef.current === reqId) setLoading(false);
     }
-  }, [query, projectFilter, modelFilter]);
+  }, [query, projectFilter, modelFilter, sortBy]);
 
   useEffect(() => {
     const t = setTimeout(fetchSessions, 150);
@@ -318,6 +321,8 @@ export default function App() {
               onProjectFilterChange={setProjectFilter}
               modelFilter={modelFilter}
               onModelFilterChange={setModelFilter}
+              sortBy={sortBy}
+              onSortByChange={setSortBy}
               loading={loading}
               searchInputRef={searchInputRef}
               onPinToggled={onPinToggled}

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useState, type Ref } from "react";
 import { Loader2, Star } from "lucide-react";
-import { setSessionPinned, type SessionRow } from "@/lib/ipc";
+import {
+  SORT_OPTIONS,
+  setSessionPinned,
+  type SessionRow,
+  type SortKey,
+} from "@/lib/ipc";
 import {
   cn,
   formatRelative,
@@ -20,6 +25,8 @@ interface Props {
   onProjectFilterChange: (p: string | null) => void;
   modelFilter: string | null;
   onModelFilterChange: (m: string | null) => void;
+  sortBy: SortKey;
+  onSortByChange: (k: SortKey) => void;
   loading: boolean;
   searchInputRef?: Ref<HTMLInputElement>;
   onPinToggled: () => void;
@@ -237,6 +244,23 @@ export function SessionList(props: Props) {
             {MODEL_OPTIONS.map((m) => (
               <option key={m} value={m}>
                 {m[0].toUpperCase() + m.slice(1)}
+              </option>
+            ))}
+          </select>
+          <select
+            value={props.sortBy}
+            onChange={(e) => props.onSortByChange(e.target.value as SortKey)}
+            className="rounded-md px-2 py-1 outline-none"
+            style={{
+              background: "var(--surface)",
+              color: "var(--text)",
+              border: "1px solid var(--border)",
+            }}
+            title="Sort sessions"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.key} value={opt.key}>
+                {opt.label}
               </option>
             ))}
           </select>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -46,6 +46,23 @@ export interface ToolUse {
   input_preview: string;
 }
 
+export type SortKey =
+  | "newest"
+  | "oldest"
+  | "modified"
+  | "project"
+  | "messages"
+  | "cost";
+
+export const SORT_OPTIONS: ReadonlyArray<{ key: SortKey; label: string }> = [
+  { key: "newest", label: "Newest first" },
+  { key: "oldest", label: "Oldest first" },
+  { key: "modified", label: "Recently modified" },
+  { key: "project", label: "Project name (A–Z)" },
+  { key: "messages", label: "Most messages" },
+  { key: "cost", label: "Highest estimated cost" },
+];
+
 export interface ListArgs {
   query?: string;
   projectDir?: string;
@@ -53,6 +70,7 @@ export interface ListArgs {
   startedAfterMs?: number;
   startedBeforeMs?: number;
   limit?: number;
+  sortBy?: SortKey;
 }
 
 export async function listSessions(args: ListArgs = {}): Promise<SessionRow[]> {


### PR DESCRIPTION
Adds a Sort dropdown to the sidebar toolbar so users can reorder
sessions by created date, last modified, project name (A–Z), message
count, or estimated cost. Default remains "Newest first" and an active
search query still uses bm25 relevance until the user picks an explicit
sort, so existing UX carries over unchanged.

Closes #1

https://claude.ai/code/session_01XCeb8bSAxGoTb5NnUaqhKa