### PR TITLE
feat: keyboard shortcuts, in-transcript find, and session pinning

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -36,6 +36,7 @@ pub struct SessionRow {
     pub tool_calls: serde_json::Value,
     pub files_touched: Vec<String>,
     pub claude_version: Option<String>,
+    pub pinned_at: Option<i64>,
     #[serde(default)]
     pub snippet: Option<String>,
 }
@@ -80,6 +81,7 @@ fn row_from_raw(
     tool_calls_json: String,
     files_touched_json: String,
     claude_version: Option<String>,
+    pinned_at: Option<i64>,
     snippet: Option<String>,
 ) -> SessionRow {
     let models_used: Vec<String> = serde_json::from_str(&models_used_json).unwrap_or_default();
@@ -109,6 +111,7 @@ fn row_from_raw(
         tool_calls,
         files_touched,
         claude_version,
+        pinned_at,
         snippet,
     }
 }
@@ -140,7 +143,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                    s.input_tokens, s.output_tokens, s.cache_read_tokens, s.cache_creation_tokens,
                    s.estimated_cost_usd, s.has_errors,
                    s.models_used_json, s.tool_calls_json, s.files_touched_json,
-                   s.claude_version,
+                   s.claude_version, s.pinned_at,
                    snippet(sessions_fts, 4, '<mark>', '</mark>', '…', 12) AS snippet
             FROM sessions_fts
             JOIN sessions s USING(session_id)
@@ -178,7 +181,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                     r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?,
                     r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?, r.get(11)?, r.get(12)?, r.get(13)?,
                     r.get(14)?, r.get(15)?, r.get(16)?, r.get(17)?, r.get(18)?, r.get(19)?, r.get(20)?,
-                    r.get(21)?, r.get(22)?,
+                    r.get(21)?, r.get(22)?, r.get(23)?,
                 ))
             })
             .map_err(|e| e.to_string())?;
@@ -223,7 +226,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                    estimated_cost_usd, has_errors,
                    models_used_json, tool_calls_json, files_touched_json,
-                   claude_version
+                   claude_version, pinned_at
             FROM sessions
             {where_clause}
             ORDER BY started_at_ms DESC
@@ -241,7 +244,7 @@ pub fn list_sessions(state: State<'_, AppState>, args: ListArgs) -> std::result:
                     r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?,
                     r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?, r.get(11)?, r.get(12)?, r.get(13)?,
                     r.get(14)?, r.get(15)?, r.get(16)?, r.get(17)?, r.get(18)?, r.get(19)?, r.get(20)?,
-                    r.get(21)?, None,
+                    r.get(21)?, r.get(22)?, None,
                 ))
             })
             .map_err(|e| e.to_string())?;
@@ -337,7 +340,7 @@ pub fn get_session(
                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                    estimated_cost_usd, has_errors,
                    models_used_json, tool_calls_json, files_touched_json,
-                   claude_version
+                   claude_version, pinned_at
             FROM sessions WHERE session_id = ?1
             "#,
             params![session_id],
@@ -346,7 +349,7 @@ pub fn get_session(
                     r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?,
                     r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?, r.get(11)?, r.get(12)?, r.get(13)?,
                     r.get(14)?, r.get(15)?, r.get(16)?, r.get(17)?, r.get(18)?, r.get(19)?, r.get(20)?,
-                    r.get(21)?, None,
+                    r.get(21)?, r.get(22)?, None,
                 ))
             },
         )
@@ -466,6 +469,71 @@ pub fn export_markdown(
 #[tauri::command]
 pub fn resume_command(session_id: String) -> std::result::Result<String, String> {
     Ok(format!("claude --resume {}", session_id))
+}
+
+#[tauri::command]
+pub fn set_session_pinned(
+    state: State<'_, AppState>,
+    session_id: String,
+    pinned: bool,
+) -> std::result::Result<(), String> {
+    let conn = state.db.lock();
+    if pinned {
+        conn.execute(
+            "UPDATE sessions SET pinned_at = ?1 WHERE session_id = ?2",
+            params![
+                chrono::Utc::now().timestamp_millis(),
+                session_id,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    } else {
+        conn.execute(
+            "UPDATE sessions SET pinned_at = NULL WHERE session_id = ?1",
+            params![session_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn list_pinned_sessions(
+    state: State<'_, AppState>,
+) -> std::result::Result<Vec<SessionRow>, String> {
+    let conn = state.db.lock();
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT session_id, project_dir, cwd, git_branch,
+                   custom_title, first_user_msg, ai_summary,
+                   started_at_ms, ended_at_ms,
+                   message_count, user_message_count, assistant_message_count,
+                   input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                   estimated_cost_usd, has_errors,
+                   models_used_json, tool_calls_json, files_touched_json,
+                   claude_version, pinned_at
+            FROM sessions
+            WHERE pinned_at IS NOT NULL
+            ORDER BY pinned_at DESC
+            "#,
+        )
+        .map_err(|e| e.to_string())?;
+    let rows_iter = stmt
+        .query_map([], |r| {
+            Ok(row_from_raw(
+                r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?,
+                r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?, r.get(11)?, r.get(12)?, r.get(13)?,
+                r.get(14)?, r.get(15)?, r.get(16)?, r.get(17)?, r.get(18)?, r.get(19)?, r.get(20)?,
+                r.get(21)?, r.get(22)?, None,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for r in rows_iter {
+        out.push(r.map_err(|e| e.to_string())?);
+    }
+    Ok(out)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -22,6 +22,13 @@ pub fn open(path: &Path) -> Result<Connection> {
 
 pub fn init_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA).context("init schema")?;
+    // Additive migrations for columns introduced after the initial schema.
+    // SQLite returns an error if the column already exists; we swallow it.
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN pinned_at INTEGER", []);
+    let _ = conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_pinned ON sessions(pinned_at) WHERE pinned_at IS NOT NULL",
+        [],
+    );
     Ok(())
 }
 
@@ -50,7 +57,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     estimated_cost_usd      REAL NOT NULL,
     has_errors              INTEGER NOT NULL,
     file_path               TEXT NOT NULL,
-    file_mtime_ms           INTEGER NOT NULL
+    file_mtime_ms           INTEGER NOT NULL,
+    pinned_at               INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_started  ON sessions(started_at_ms DESC);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,8 @@ pub fn run() {
             commands::resume_command,
             commands::write_text_file,
             commands::reindex,
+            commands::set_session_pinned,
+            commands::list_pinned_sessions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import {
+  listPinnedSessions,
   listProjects,
   listSessions,
   type SessionRow,
 } from "@/lib/ipc";
 import { SessionList } from "@/components/session-list";
 import { SessionDetail } from "@/components/session-detail";
+import { isMac } from "@/lib/utils";
 
 const DEFAULT_LEFT_WIDTH = 380;
 
@@ -15,12 +17,14 @@ export default function App() {
   const [projectFilter, setProjectFilter] = useState<string | null>(null);
   const [modelFilter, setModelFilter] = useState<string | null>(null);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [pinnedSessions, setPinnedSessions] = useState<SessionRow[]>([]);
   const [projects, setProjects] = useState<Array<[string, number]>>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH);
   const dragRef = useRef<{ startX: number; startW: number } | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   // debounced fetch
   const reqIdRef = useRef(0);
@@ -45,39 +49,51 @@ export default function App() {
     return () => clearTimeout(t);
   }, [fetchSessions]);
 
+  const fetchPinned = useCallback(() => {
+    listPinnedSessions().then(setPinnedSessions);
+  }, []);
+
   useEffect(() => {
     listProjects().then(setProjects);
-  }, []);
+    fetchPinned();
+  }, [fetchPinned]);
 
   useEffect(() => {
     const un = listen("sessions-updated", () => {
       fetchSessions();
+      fetchPinned();
       listProjects().then(setProjects);
     });
     return () => {
       un.then((fn) => fn());
     };
-  }, [fetchSessions]);
+  }, [fetchSessions, fetchPinned]);
 
-  const selected = useMemo(
-    () => sessions.find((s) => s.session_id === selectedId) ?? null,
-    [sessions, selectedId]
+  const pinnedIds = useMemo(
+    () => new Set(pinnedSessions.map((s) => s.session_id)),
+    [pinnedSessions]
   );
 
-  // Sessions in the order they are rendered on screen (grouped by project,
-  // insertion-order-preserving). Arrow-key navigation must follow this order,
-  // not the raw chronological order from the backend.
+  const selected = useMemo(() => {
+    const byId = (s: SessionRow) => s.session_id === selectedId;
+    return pinnedSessions.find(byId) ?? sessions.find(byId) ?? null;
+  }, [sessions, pinnedSessions, selectedId]);
+
+  // Sessions in the order they are rendered on screen (pinned first, then
+  // grouped by project, insertion-order-preserving). Arrow-key navigation
+  // must follow this visual order.
   const visualOrder = useMemo(() => {
+    const flat: SessionRow[] = [...pinnedSessions];
     const byProject = new Map<string, SessionRow[]>();
     for (const s of sessions) {
+      if (pinnedIds.has(s.session_id)) continue;
       const key = s.project_dir;
       if (!byProject.has(key)) byProject.set(key, []);
       byProject.get(key)!.push(s);
     }
-    const flat: SessionRow[] = [];
     for (const rows of byProject.values()) flat.push(...rows);
     return flat;
-  }, [sessions]);
+  }, [sessions, pinnedSessions, pinnedIds]);
 
   // Auto-select first session when query changes and current selection falls off.
   useEffect(() => {
@@ -123,11 +139,58 @@ export default function App() {
     el?.scrollIntoView({ block: "nearest" });
   }, [selectedId]);
 
+  // Shortcuts to focus and clear the search input.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const input = searchInputRef.current;
+
+      const modKey = isMac() ? e.metaKey : e.ctrlKey;
+      if (modKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        input?.focus();
+        input?.select();
+        return;
+      }
+
+      if (e.key === "/") {
+        if (target?.isContentEditable) return;
+        const tag = target?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        e.preventDefault();
+        input?.focus();
+        input?.select();
+        return;
+      }
+
+      if (e.key === "Escape") {
+        // Only handle Esc when the search input is focused — otherwise leave
+        // it alone so it can close dialogs, details, etc.
+        if (target !== input) return;
+        if (query.length > 0) {
+          setQuery("");
+        } else {
+          input?.blur();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [query]);
+
   const onSessionPatched = useCallback((patched: SessionRow) => {
     setSessions((rows) =>
       rows.map((r) => (r.session_id === patched.session_id ? patched : r))
     );
+    setPinnedSessions((rows) =>
+      rows.map((r) => (r.session_id === patched.session_id ? patched : r))
+    );
   }, []);
+
+  const onPinToggled = useCallback(() => {
+    fetchPinned();
+    fetchSessions();
+  }, [fetchPinned, fetchSessions]);
 
   const onDragStart = (e: React.MouseEvent<HTMLDivElement>) => {
     dragRef.current = { startX: e.clientX, startW: leftWidth };
@@ -153,6 +216,7 @@ export default function App() {
       <div style={{ width: leftWidth, flex: "0 0 auto" }}>
         <SessionList
           sessions={sessions}
+          pinnedSessions={pinnedSessions}
           projects={projects}
           selectedId={selectedId}
           onSelect={setSelectedId}
@@ -163,6 +227,8 @@ export default function App() {
           modelFilter={modelFilter}
           onModelFilterChange={setModelFilter}
           loading={loading}
+          searchInputRef={searchInputRef}
+          onPinToggled={onPinToggled}
         />
       </div>
       <div
@@ -171,7 +237,11 @@ export default function App() {
         style={{ background: "var(--border)" }}
       />
       <div className="flex-1 min-w-0">
-        <SessionDetail session={selected} onSessionPatched={onSessionPatched} />
+        <SessionDetail
+          session={selected}
+          onSessionPatched={onSessionPatched}
+          onPinToggled={onPinToggled}
+        />
       </div>
     </div>
   );

--- a/src/components/session-detail.tsx
+++ b/src/components/session-detail.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { Star } from "lucide-react";
 import {
   copyResumeCommand,
   exportMarkdown,
   generateSummary,
   getTranscript,
   saveMarkdownToDisk,
+  setSessionPinned,
   type SessionRow,
   type Turn,
 } from "@/lib/ipc";
@@ -23,6 +25,7 @@ import { Transcript } from "./transcript";
 interface Props {
   session: SessionRow | null;
   onSessionPatched: (s: SessionRow) => void;
+  onPinToggled: () => void;
 }
 
 function heuristicTldr(s: SessionRow): string {
@@ -31,7 +34,7 @@ function heuristicTldr(s: SessionRow): string {
   return "(no user prompts in this session)";
 }
 
-export function SessionDetail({ session, onSessionPatched }: Props) {
+export function SessionDetail({ session, onSessionPatched, onPinToggled }: Props) {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [summaryBusy, setSummaryBusy] = useState(false);
   const [summaryError, setSummaryError] = useState<string | null>(null);
@@ -110,6 +113,13 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
     }
   }, [session?.cwd]);
 
+  const onTogglePin = useCallback(async () => {
+    if (!session) return;
+    const nextPinned = session.pinned_at === null;
+    await setSessionPinned(session.session_id, nextPinned);
+    onPinToggled();
+  }, [session, onPinToggled]);
+
   if (!session) {
     return (
       <div
@@ -145,6 +155,23 @@ export function SessionDetail({ session, onSessionPatched }: Props) {
             {title}
           </h2>
           <div className="flex shrink-0 gap-2">
+            <button
+              onClick={onTogglePin}
+              aria-label={session.pinned_at === null ? "Pin session" : "Unpin session"}
+              title={session.pinned_at === null ? "Pin" : "Unpin"}
+              className="rounded-md border px-2 py-1.5 text-xs font-medium"
+              style={{
+                background: "var(--surface)",
+                borderColor: "var(--border)",
+                color: session.pinned_at === null ? "var(--text-muted)" : "var(--accent)",
+              }}
+            >
+              <Star
+                size={14}
+                fill={session.pinned_at === null ? "none" : "currentColor"}
+                strokeWidth={1.75}
+              />
+            </button>
             <button
               onClick={onCopyResume}
               className="rounded-md px-3 py-1.5 text-xs font-medium"

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
-import type { SessionRow } from "@/lib/ipc";
+import { useMemo, useState, type Ref } from "react";
+import { Star } from "lucide-react";
+import { setSessionPinned, type SessionRow } from "@/lib/ipc";
 import {
   cn,
   formatRelative,
@@ -9,6 +10,7 @@ import {
 
 interface Props {
   sessions: SessionRow[];
+  pinnedSessions: SessionRow[];
   projects: Array<[string, number]>;
   selectedId: string | null;
   onSelect: (id: string) => void;
@@ -19,6 +21,8 @@ interface Props {
   modelFilter: string | null;
   onModelFilterChange: (m: string | null) => void;
   loading: boolean;
+  searchInputRef?: Ref<HTMLInputElement>;
+  onPinToggled: () => void;
 }
 
 function stripCaveat(raw: string): string {
@@ -57,20 +61,126 @@ function modelBadge(model: string): string {
 const MODEL_OPTIONS = ["opus", "sonnet", "haiku"];
 
 export function SessionList(props: Props) {
+  const [pinnedCollapsed, setPinnedCollapsed] = useState(false);
+
+  const pinnedIds = useMemo(
+    () => new Set(props.pinnedSessions.map((s) => s.session_id)),
+    [props.pinnedSessions]
+  );
+
   const grouped = useMemo(() => {
     const map = new Map<string, SessionRow[]>();
     for (const s of props.sessions) {
+      if (pinnedIds.has(s.session_id)) continue;
       const k = s.project_dir;
       if (!map.has(k)) map.set(k, []);
       map.get(k)!.push(s);
     }
     return Array.from(map.entries());
-  }, [props.sessions]);
+  }, [props.sessions, pinnedIds]);
+
+  const togglePin = async (s: SessionRow, e: React.MouseEvent) => {
+    e.stopPropagation();
+    await setSessionPinned(s.session_id, s.pinned_at === null);
+    props.onPinToggled();
+  };
+
+  const renderRow = (s: SessionRow) => {
+    const title = titleFor(s);
+    const models = s.models_used.map(modelBadge);
+    const uniqueModels = Array.from(new Set(models));
+    const isSelected = s.session_id === props.selectedId;
+    const isPinned = s.pinned_at !== null;
+    return (
+      <div
+        key={s.session_id}
+        data-session-id={s.session_id}
+        className={cn(
+          "group relative block w-full text-left",
+          "transition-colors",
+          !isSelected && "hover:bg-[var(--surface-2)]"
+        )}
+        style={{
+          borderLeft: `2px solid ${isSelected ? "var(--accent)" : "transparent"}`,
+          background: isSelected ? "var(--accent-soft)" : "transparent",
+        }}
+      >
+        <button
+          onClick={() => props.onSelect(s.session_id)}
+          className="block w-full text-left py-2 pr-9 text-sm"
+          style={{ paddingLeft: "20px" }}
+        >
+          <div
+            className="truncate font-medium"
+            style={{ fontSize: "14px" }}
+            title={title}
+          >
+            {title}
+          </div>
+          {s.snippet && (
+            <div
+              className="truncate mt-1"
+              style={{ color: "var(--text-muted)", fontSize: "12px" }}
+              dangerouslySetInnerHTML={{ __html: sanitizeSnippet(s.snippet) }}
+            />
+          )}
+          <div
+            className="mt-1 flex items-center gap-2"
+            style={{ color: "var(--text-muted)", fontSize: "11px" }}
+          >
+            <span>{formatRelative(s.ended_at_ms || s.started_at_ms)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{s.message_count} msgs</span>
+            {uniqueModels.length > 0 && (
+              <>
+                <span aria-hidden="true">·</span>
+                {uniqueModels.map((m) => (
+                  <span
+                    key={m}
+                    className="rounded px-1.5 py-0.5 text-[10px]"
+                    style={{
+                      background: "var(--surface-3)",
+                      color: "var(--text)",
+                    }}
+                  >
+                    {m}
+                  </span>
+                ))}
+              </>
+            )}
+            {s.has_errors && (
+              <span style={{ color: "var(--danger)" }}>· errors</span>
+            )}
+          </div>
+        </button>
+        <button
+          onClick={(e) => togglePin(s, e)}
+          aria-label={isPinned ? "Unpin session" : "Pin session"}
+          title={isPinned ? "Unpin" : "Pin"}
+          className={cn(
+            "absolute right-2 top-2 rounded p-1",
+            "transition-opacity",
+            isPinned ? "opacity-100" : "opacity-0 group-hover:opacity-100 focus:opacity-100"
+          )}
+          style={{
+            color: isPinned ? "var(--accent)" : "var(--text-muted)",
+          }}
+        >
+          <Star
+            size={14}
+            fill={isPinned ? "currentColor" : "none"}
+            strokeWidth={1.75}
+          />
+        </button>
+      </div>
+    );
+  };
 
   return (
     <div className="flex h-full flex-col border-r" style={{ borderColor: "var(--border)" }}>
       <div className="p-3 space-y-2" style={{ background: "var(--surface-2)" }}>
         <input
+          ref={props.searchInputRef}
           type="text"
           placeholder="Search conversations…"
           value={props.query}
@@ -126,11 +236,33 @@ export function SessionList(props: Props) {
             Loading…
           </div>
         )}
-        {!props.loading && props.sessions.length === 0 && (
+        {!props.loading && props.sessions.length === 0 && props.pinnedSessions.length === 0 && (
           <div className="p-6 text-sm" style={{ color: "var(--text-muted)" }}>
             No sessions match.
           </div>
         )}
+
+        {props.pinnedSessions.length > 0 && (
+          <div className="pb-2">
+            <button
+              onClick={() => setPinnedCollapsed((c) => !c)}
+              className="sticky top-0 z-10 flex w-full items-center gap-1 px-3 pb-1.5 pt-3 text-left text-[10.5px] font-semibold uppercase tracking-[0.08em]"
+              style={{
+                color: "var(--accent)",
+                background: "var(--surface-2)",
+                borderBottom: "1px solid var(--border)",
+              }}
+            >
+              <span aria-hidden="true">{pinnedCollapsed ? "▸" : "▾"}</span>
+              <span>Pinned</span>
+              <span style={{ color: "var(--text-muted)", opacity: 0.8 }}>
+                · {props.pinnedSessions.length}
+              </span>
+            </button>
+            {!pinnedCollapsed && props.pinnedSessions.map(renderRow)}
+          </div>
+        )}
+
         {grouped.map(([project, rows]) => (
           <div key={project} className="pb-2">
             <div
@@ -146,72 +278,7 @@ export function SessionList(props: Props) {
                 · {rows.length}
               </span>
             </div>
-            {rows.map((s) => {
-              const title = titleFor(s);
-              const models = s.models_used.map(modelBadge);
-              const uniqueModels = Array.from(new Set(models));
-              const isSelected = s.session_id === props.selectedId;
-              return (
-                <button
-                  key={s.session_id}
-                  data-session-id={s.session_id}
-                  onClick={() => props.onSelect(s.session_id)}
-                  className={cn(
-                    "block w-full text-left pr-3 py-2 text-sm",
-                    "transition-colors",
-                    !isSelected && "hover:bg-[var(--surface-2)]"
-                  )}
-                  style={{
-                    paddingLeft: "20px",
-                    borderLeft: `2px solid ${isSelected ? "var(--accent)" : "transparent"}`,
-                    background: isSelected ? "var(--accent-soft)" : "transparent",
-                  }}
-                >
-                  <div
-                    className="truncate font-medium"
-                    style={{ fontSize: "14px" }}
-                    title={title}
-                  >
-                    {title}
-                  </div>
-                  {s.snippet && (
-                    <div
-                      className="truncate mt-1"
-                      style={{ color: "var(--text-muted)", fontSize: "12px" }}
-                      dangerouslySetInnerHTML={{ __html: sanitizeSnippet(s.snippet) }}
-                    />
-                  )}
-                  <div
-                    className="mt-1 flex items-center gap-2"
-                    style={{ color: "var(--text-muted)", fontSize: "11px" }}
-                  >
-                    <span>{formatRelative(s.ended_at_ms || s.started_at_ms)}</span>
-                    <span aria-hidden="true">·</span>
-                    <span>{s.message_count} msgs</span>
-                    {uniqueModels.length > 0 && (
-                      <>
-                        <span aria-hidden="true">·</span>
-                        {uniqueModels.map((m) => (
-                          <span
-                            key={m}
-                            className="rounded px-1.5 py-0.5 text-[10px]"
-                            style={{
-                              background: "var(--surface-3)",
-                              color: "var(--text)",
-                            }}
-                          >
-                            {m}
-                          </span>
-                        ))}
-                      </>
-                    )}
-                    {s.has_errors && (
-                      <span style={{ color: "var(--danger)" }}>· errors</span>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
+            {rows.map(renderRow)}
           </div>
         ))}
       </div>

--- a/src/components/transcript.tsx
+++ b/src/components/transcript.tsx
@@ -1,17 +1,171 @@
-import { useRef, useState } from "react";
+import {
+  cloneElement,
+  Fragment,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { isMac } from "@/lib/utils";
 import type { Turn } from "@/lib/ipc";
 
 interface Props {
   turns: Turn[];
 }
 
-function TurnCard({ turn }: { turn: Turn }) {
+interface Match {
+  turnIndex: number;
+  /** Ordinal of this match within its turn's text (0-indexed). */
+  localIdx: number;
+}
+
+interface HighlightState {
+  count: number;
+  currentInTurn: number | null;
+}
+
+function countMatches(text: string, q: string): number {
+  if (!q) return 0;
+  const lt = text.toLowerCase();
+  const lq = q.toLowerCase();
+  let i = 0;
+  let n = 0;
+  while (i < lt.length) {
+    const f = lt.indexOf(lq, i);
+    if (f === -1) break;
+    n += 1;
+    i = f + lq.length;
+  }
+  return n;
+}
+
+function highlightText(
+  text: string,
+  q: string,
+  state: HighlightState
+): ReactNode {
+  if (!q) return text;
+  const parts: ReactNode[] = [];
+  const lq = q.toLowerCase();
+  const lt = text.toLowerCase();
+  let i = 0;
+  while (i <= text.length) {
+    const found = lt.indexOf(lq, i);
+    if (found === -1) {
+      if (i < text.length) parts.push(text.slice(i));
+      break;
+    }
+    if (found > i) parts.push(text.slice(i, found));
+    const matchText = text.slice(found, found + q.length);
+    const isCurrent = state.count === state.currentInTurn;
+    parts.push(
+      <mark
+        key={`m-${state.count}`}
+        data-find-current={isCurrent ? "true" : undefined}
+        style={
+          isCurrent
+            ? {
+                background: "var(--accent)",
+                color: "white",
+                padding: "0 2px",
+                borderRadius: "2px",
+              }
+            : {
+                background: "var(--accent-soft)",
+                color: "var(--text)",
+                padding: "0 2px",
+                borderRadius: "2px",
+              }
+        }
+      >
+        {matchText}
+      </mark>
+    );
+    state.count += 1;
+    i = found + q.length;
+  }
+  return <>{parts}</>;
+}
+
+function highlightNode(
+  node: ReactNode,
+  q: string,
+  state: HighlightState
+): ReactNode {
+  if (typeof node === "string") return highlightText(node, q, state);
+  if (typeof node === "number" || node == null || typeof node === "boolean")
+    return node;
+  if (Array.isArray(node)) {
+    return node.map((c, i) => (
+      <Fragment key={i}>{highlightNode(c, q, state)}</Fragment>
+    ));
+  }
+  if (isValidElement(node)) {
+    // Skip code blocks — wrapping <mark> inside monospace blocks tends to
+    // break layout, and matches in code are niche for v1.
+    if (node.type === "code" || node.type === "pre") return node;
+    const props = node.props as { children?: ReactNode };
+    return cloneElement(
+      node,
+      {},
+      highlightNode(props.children, q, state)
+    );
+  }
+  return node;
+}
+
+function makeMarkdownComponents(
+  query: string,
+  currentInTurn: number | null
+): Components | undefined {
+  if (!query) return undefined;
+  const state: HighlightState = { count: 0, currentInTurn };
+  const hl = (children: ReactNode) => highlightNode(children, query, state);
+  return {
+    p: ({ children, node: _n, ...rest }) => <p {...rest}>{hl(children)}</p>,
+    li: ({ children, node: _n, ...rest }) => <li {...rest}>{hl(children)}</li>,
+    em: ({ children, node: _n, ...rest }) => <em {...rest}>{hl(children)}</em>,
+    strong: ({ children, node: _n, ...rest }) => (
+      <strong {...rest}>{hl(children)}</strong>
+    ),
+    a: ({ children, node: _n, ...rest }) => <a {...rest}>{hl(children)}</a>,
+    blockquote: ({ children, node: _n, ...rest }) => (
+      <blockquote {...rest}>{hl(children)}</blockquote>
+    ),
+    h1: ({ children, node: _n, ...rest }) => <h1 {...rest}>{hl(children)}</h1>,
+    h2: ({ children, node: _n, ...rest }) => <h2 {...rest}>{hl(children)}</h2>,
+    h3: ({ children, node: _n, ...rest }) => <h3 {...rest}>{hl(children)}</h3>,
+    h4: ({ children, node: _n, ...rest }) => <h4 {...rest}>{hl(children)}</h4>,
+    h5: ({ children, node: _n, ...rest }) => <h5 {...rest}>{hl(children)}</h5>,
+    h6: ({ children, node: _n, ...rest }) => <h6 {...rest}>{hl(children)}</h6>,
+    td: ({ children, node: _n, ...rest }) => <td {...rest}>{hl(children)}</td>,
+    th: ({ children, node: _n, ...rest }) => <th {...rest}>{hl(children)}</th>,
+  };
+}
+
+function TurnCard({
+  turn,
+  query,
+  currentInTurn,
+}: {
+  turn: Turn;
+  query: string;
+  currentInTurn: number | null;
+}) {
   const [toolsOpen, setToolsOpen] = useState(false);
   const isUser = turn.role === "user";
   const isAssistant = turn.role === "assistant";
+
+  const components = useMemo(
+    () => makeMarkdownComponents(query, currentInTurn),
+    [query, currentInTurn]
+  );
 
   return (
     <div
@@ -31,11 +185,10 @@ function TurnCard({ turn }: { turn: Turn }) {
       </div>
 
       {turn.text.trim().length > 0 && (
-        <div
-          className="md max-w-none"
-          style={{ color: "var(--text)" }}
-        >
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.text}</ReactMarkdown>
+        <div className="md max-w-none" style={{ color: "var(--text)" }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+            {turn.text}
+          </ReactMarkdown>
         </div>
       )}
 
@@ -81,6 +234,11 @@ function TurnCard({ turn }: { turn: Turn }) {
 
 export function Transcript({ turns }: Props) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findCur, setFindCur] = useState(0);
 
   const virtualizer = useVirtualizer({
     count: turns.length,
@@ -89,6 +247,108 @@ export function Transcript({ turns }: Props) {
     overscan: 6,
     measureElement: (el) => el.getBoundingClientRect().height,
   });
+
+  // Build the flat list of matches across all turns.
+  const matches: Match[] = useMemo(() => {
+    const q = findQuery.trim();
+    if (!q) return [];
+    const out: Match[] = [];
+    for (let i = 0; i < turns.length; i++) {
+      const n = countMatches(turns[i].text, q);
+      for (let k = 0; k < n; k++) {
+        out.push({ turnIndex: i, localIdx: k });
+      }
+    }
+    return out;
+  }, [turns, findQuery]);
+
+  // Reset transcript-local find state when the session (turns identity) changes.
+  useEffect(() => {
+    setFindOpen(false);
+    setFindQuery("");
+    setFindCur(0);
+  }, [turns]);
+
+  // Clamp current match index to the valid range when matches change.
+  useEffect(() => {
+    if (matches.length === 0) {
+      if (findCur !== 0) setFindCur(0);
+      return;
+    }
+    if (findCur >= matches.length) setFindCur(matches.length - 1);
+  }, [matches, findCur]);
+
+  const scrollToMatch = useCallback(
+    (idx: number) => {
+      const m = matches[idx];
+      if (!m) return;
+      virtualizer.scrollToIndex(m.turnIndex, { align: "center" });
+      // After the virtualizer measures + paints, center the specific <mark>.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          parentRef.current
+            ?.querySelector<HTMLElement>('[data-find-current="true"]')
+            ?.scrollIntoView({ block: "center", behavior: "smooth" });
+        });
+      });
+    },
+    [matches, virtualizer]
+  );
+
+  const cycleMatch = useCallback(
+    (delta: number) => {
+      if (matches.length === 0) return;
+      const next = (findCur + delta + matches.length) % matches.length;
+      setFindCur(next);
+      scrollToMatch(next);
+    },
+    [matches.length, findCur, scrollToMatch]
+  );
+
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    requestAnimationFrame(() => {
+      findInputRef.current?.focus();
+      findInputRef.current?.select();
+    });
+  }, []);
+
+  const closeFind = useCallback(() => {
+    setFindOpen(false);
+    setFindQuery("");
+  }, []);
+
+  // Cmd+F / Ctrl+F to open the find bar when the transcript is visible.
+  useEffect(() => {
+    if (turns.length === 0) return;
+    const handler = (e: KeyboardEvent) => {
+      const modKey = isMac() ? e.metaKey : e.ctrlKey;
+      if (modKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        openFind();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [turns.length, openFind]);
+
+  const onFindKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeFind();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      cycleMatch(e.shiftKey ? -1 : 1);
+    }
+  };
+
+  // When query changes, jump to first match.
+  useEffect(() => {
+    if (!findOpen) return;
+    if (matches.length > 0 && findCur === 0) {
+      scrollToMatch(0);
+    }
+  }, [matches, findOpen, findCur, scrollToMatch]);
 
   if (turns.length === 0) {
     return (
@@ -101,34 +361,125 @@ export function Transcript({ turns }: Props) {
     );
   }
 
+  const currentMatch = matches[findCur] ?? null;
+
   return (
-    <div ref={parentRef} className="h-full overflow-y-auto">
-      <div
-        style={{
-          height: virtualizer.getTotalSize(),
-          position: "relative",
-          width: "100%",
-        }}
-      >
-        {virtualizer.getVirtualItems().map((vi) => {
-          const turn = turns[vi.index];
-          return (
-            <div
-              key={vi.key}
-              ref={virtualizer.measureElement}
-              data-index={vi.index}
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: "100%",
-                transform: `translateY(${vi.start}px)`,
-              }}
-            >
-              <TurnCard turn={turn} />
-            </div>
-          );
-        })}
+    <div className="relative flex h-full flex-col">
+      {findOpen && (
+        <div
+          className="flex items-center gap-2 border-b px-3 py-2"
+          style={{
+            background: "var(--surface-2)",
+            borderColor: "var(--border)",
+          }}
+        >
+          <input
+            ref={findInputRef}
+            type="text"
+            placeholder="Find in messages…"
+            value={findQuery}
+            onChange={(e) => {
+              setFindQuery(e.target.value);
+              setFindCur(0);
+            }}
+            onKeyDown={onFindKeyDown}
+            className="flex-1 rounded-md px-2 py-1 text-sm outline-none focus:ring-2"
+            style={{
+              background: "var(--surface)",
+              color: "var(--text)",
+              border: "1px solid var(--border)",
+            }}
+          />
+          <span
+            className="min-w-[64px] text-right text-xs tabular-nums"
+            style={{ color: "var(--text-muted)" }}
+          >
+            {findQuery.trim()
+              ? matches.length === 0
+                ? "No matches"
+                : `${findCur + 1} of ${matches.length}`
+              : ""}
+          </span>
+          <button
+            onClick={() => cycleMatch(-1)}
+            disabled={matches.length === 0}
+            aria-label="Previous match"
+            title="Previous (Shift+Enter)"
+            className="rounded px-2 py-1 text-xs disabled:opacity-40"
+            style={{
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              color: "var(--text)",
+            }}
+          >
+            ↑
+          </button>
+          <button
+            onClick={() => cycleMatch(1)}
+            disabled={matches.length === 0}
+            aria-label="Next match"
+            title="Next (Enter)"
+            className="rounded px-2 py-1 text-xs disabled:opacity-40"
+            style={{
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              color: "var(--text)",
+            }}
+          >
+            ↓
+          </button>
+          <button
+            onClick={closeFind}
+            aria-label="Close find"
+            title="Close (Esc)"
+            className="rounded px-2 py-1 text-xs"
+            style={{
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              color: "var(--text-muted)",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      <div ref={parentRef} className="flex-1 overflow-y-auto">
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            position: "relative",
+            width: "100%",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((vi) => {
+            const turn = turns[vi.index];
+            const currentInTurn =
+              currentMatch && currentMatch.turnIndex === vi.index
+                ? currentMatch.localIdx
+                : null;
+            return (
+              <div
+                key={vi.key}
+                ref={virtualizer.measureElement}
+                data-index={vi.index}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${vi.start}px)`,
+                }}
+              >
+                <TurnCard
+                  turn={turn}
+                  query={findQuery.trim()}
+                  currentInTurn={currentInTurn}
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -25,6 +25,7 @@ export interface SessionRow {
   tool_calls: Record<string, number>;
   files_touched: string[];
   claude_version: string | null;
+  pinned_at: number | null;
   snippet: string | null;
 }
 
@@ -95,4 +96,12 @@ export async function saveMarkdownToDisk(sessionId: string, md: string): Promise
 
 export async function reindex(): Promise<{ total: number; indexed: number; skipped: number }> {
   return invoke("reindex");
+}
+
+export async function setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
+  return invoke("set_session_pinned", { sessionId, pinned });
+}
+
+export async function listPinnedSessions(): Promise<SessionRow[]> {
+  return invoke<SessionRow[]>("list_pinned_sessions");
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -57,6 +57,10 @@ export function basename(p: string | null | undefined): string {
   return parts[parts.length - 1] ?? p;
 }
 
+export function isMac(): boolean {
+  return typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+}
+
 export function shortProject(p: string): string {
   const home = "/Users/";
   if (p.startsWith(home)) {


### PR DESCRIPTION
## Summary

Ships three independent features from the improvements review:

- **#7 — sidebar search shortcuts.** `Cmd+K` / `Ctrl+K` focuses the search from anywhere; `/` focuses it (skipped inside inputs); `Esc` clears the query or blurs when the search is focused.
- **#8 — `Cmd+F` in-transcript find.** Find bar with `N of M` counter, `Enter` / `Shift+Enter` cycling, and inline `<mark>` highlighting of matches via a ReactMarkdown `components` override that recursively walks text nodes (skips `pre` / `code`). Virtualizer `scrollToIndex` + double-rAF `scrollIntoView` centers the active match inside long turns.
- **#9 — pin / favorite sessions.** New `pinned_at INTEGER` column on `sessions` via additive `ALTER TABLE` migration (index lives safely outside the initial `execute_batch` so existing DBs migrate without panicking). `set_session_pinned` + `list_pinned_sessions` commands. The sidebar renders a collapsible "Pinned" group above the per-project groups that stays visible regardless of active filter / search. Star toggle on each row (hover-revealed when unpinned) and in the detail header. `ON CONFLICT DO UPDATE` intentionally omits `pinned_at` so re-indexing preserves pins. Arrow-key `visualOrder` updated to traverse pinned → projects.

Closes #7, #8, #9.

## Test plan

- [ ] `bun run tauri dev` launches without panicking on an existing DB (regression from the `ALTER TABLE` ordering bug).
- [ ] `Cmd+K` focuses the sidebar search. `/` does the same when no input is focused. `Esc` clears the query; pressing `Esc` again blurs the input.
- [ ] Open a long session, press `Cmd+F`, type a query. Counter shows `1 of N`. `Enter` / `Shift+Enter` cycle. Matches highlight inline; current match is visually distinct.
- [ ] Switching sessions closes the find bar and clears state.
- [ ] Click the star on a sidebar row — row gets a filled star and a "Pinned" group appears at the top. Apply a project filter that excludes the pinned session; it still shows in the Pinned group.
- [ ] Click the star in the detail header — toggles pin state, updates both places.
- [ ] Collapse the Pinned group; `▸` / `▾` indicator flips.
- [ ] Arrow-key nav: `ArrowUp` from the topmost project row lands on the last pinned row.
- [ ] Relaunch the app — pinned state survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)