### PR TITLE
feat: global stats tab with weekly activity chart and top projects/models

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -553,3 +553,196 @@ pub async fn reindex(state: State<'_, AppState>) -> std::result::Result<serde_js
         "skipped": progress.skipped,
     }))
 }
+
+#[derive(Serialize)]
+pub struct WeeklyBucket {
+    pub week_start_ms: i64,
+    pub sessions: i64,
+    pub messages: i64,
+    pub cost_usd: f64,
+}
+
+#[derive(Serialize)]
+pub struct GlobalStats {
+    pub total_sessions: i64,
+    pub total_messages: i64,
+    pub total_user_messages: i64,
+    pub total_assistant_messages: i64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub total_cache_read_tokens: i64,
+    pub total_cache_creation_tokens: i64,
+    pub total_cost_usd: f64,
+    pub sessions_today: i64,
+    pub sessions_this_week: i64,
+    pub first_session_ms: Option<i64>,
+    pub last_session_ms: Option<i64>,
+    pub top_projects: Vec<(String, i64)>,
+    pub top_models: Vec<(String, i64)>,
+    pub weekly_activity: Vec<WeeklyBucket>,
+}
+
+#[tauri::command]
+#[allow(clippy::type_complexity)]
+pub fn global_stats(state: State<'_, AppState>) -> std::result::Result<GlobalStats, String> {
+    let conn = state.db.lock();
+
+    // Totals — COALESCE handles zero-sessions case where SUM returns NULL
+    let (
+        total_sessions, total_messages, total_user_messages, total_assistant_messages,
+        total_input_tokens, total_output_tokens, total_cache_read_tokens,
+        total_cache_creation_tokens, total_cost_usd, first_session_ms, last_session_ms,
+    ): (i64, i64, i64, i64, i64, i64, i64, i64, f64, Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(message_count), 0),
+                    COALESCE(SUM(user_message_count), 0),
+                    COALESCE(SUM(assistant_message_count), 0),
+                    COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0),
+                    COALESCE(SUM(cache_read_tokens), 0),
+                    COALESCE(SUM(cache_creation_tokens), 0),
+                    COALESCE(SUM(estimated_cost_usd), 0.0),
+                    MIN(started_at_ms),
+                    MAX(started_at_ms)
+             FROM sessions",
+            [],
+            |r| {
+                Ok((
+                    r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?,
+                    r.get(5)?, r.get(6)?, r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?,
+                ))
+            },
+        )
+        .map_err(|e| e.to_string())?;
+
+    // UTC cutoffs — midnight UTC today and rolling 7-day window
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    let today_start_ms = now_ms - (now_ms % 86_400_000);
+    let week_ago_ms = now_ms - 7 * 86_400_000;
+
+    let sessions_today: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE started_at_ms >= ?1",
+            [today_start_ms],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+
+    let sessions_this_week: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE started_at_ms >= ?1",
+            [week_ago_ms],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+
+    // Top projects via SQL GROUP BY
+    let mut stmt = conn
+        .prepare(
+            "SELECT project_dir, COUNT(*) c FROM sessions
+             GROUP BY project_dir ORDER BY c DESC LIMIT 5",
+        )
+        .map_err(|e| e.to_string())?;
+    let top_projects: Vec<(String, i64)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Top models via json_each — SQL unnests models_used_json arrays, no row-fetching to Rust
+    let mut stmt = conn
+        .prepare(
+            "SELECT j.value, COUNT(*) c
+             FROM sessions, json_each(models_used_json) j
+             GROUP BY j.value ORDER BY c DESC LIMIT 5",
+        )
+        .map_err(|e| e.to_string())?;
+    let top_models: Vec<(String, i64)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Weekly activity: SQL computes Monday-midnight-UTC epoch-ms for each session via
+    // integer day arithmetic. Epoch day 0 = Jan 1 1970 = Thursday.
+    // monday_day = d - (d+3)%7  (verified: Mon→same, Tue-Sun→preceding Mon)
+    // Rust zero-fills the 12-slot array; matching is exact integer equality.
+    let twelve_weeks_ago_ms = now_ms - 12 * 7 * 86_400_000;
+    let mut stmt = conn
+        .prepare(
+            "WITH s AS (
+               SELECT started_at_ms / 86400000 AS d,
+                      message_count, estimated_cost_usd
+               FROM sessions WHERE started_at_ms >= ?1
+             )
+             SELECT (d - (d + 3) % 7) * 86400000 AS week_ms,
+                    COUNT(*) AS sessions,
+                    COALESCE(SUM(message_count), 0) AS msgs,
+                    COALESCE(SUM(estimated_cost_usd), 0.0) AS cost
+             FROM s
+             GROUP BY week_ms
+             ORDER BY week_ms ASC",
+        )
+        .map_err(|e| e.to_string())?;
+    let sql_buckets: Vec<(i64, i64, i64, f64)> = stmt
+        .query_map([twelve_weeks_ago_ms], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Build 12-slot array using chrono for Monday-of-current-week (matches SQL formula)
+    let now_dt =
+        chrono::DateTime::<chrono::Utc>::from_timestamp_millis(now_ms).unwrap_or_default();
+    let days_since_monday = {
+        use chrono::Datelike;
+        now_dt.weekday().num_days_from_monday() as i64
+    };
+    let this_monday_ms = (now_dt - chrono::Duration::days(days_since_monday))
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc()
+        .timestamp_millis();
+
+    let mut weekly_activity: Vec<WeeklyBucket> = (0_i64..12)
+        .map(|i| WeeklyBucket {
+            week_start_ms: this_monday_ms - (11 - i) * 7 * 86_400_000,
+            sessions: 0,
+            messages: 0,
+            cost_usd: 0.0,
+        })
+        .collect();
+
+    for (week_ms, sessions, messages, cost_usd) in sql_buckets {
+        if let Some(slot) = weekly_activity.iter_mut().find(|s| s.week_start_ms == week_ms) {
+            slot.sessions = sessions;
+            slot.messages = messages;
+            slot.cost_usd = cost_usd;
+        }
+    }
+
+    Ok(GlobalStats {
+        total_sessions,
+        total_messages,
+        total_user_messages,
+        total_assistant_messages,
+        total_input_tokens,
+        total_output_tokens,
+        total_cache_read_tokens,
+        total_cache_creation_tokens,
+        total_cost_usd,
+        sessions_today,
+        sessions_this_week,
+        first_session_ms,
+        last_session_ms,
+        top_projects,
+        top_models,
+        weekly_activity,
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ pub fn run() {
             commands::reindex,
             commands::set_session_pinned,
             commands::list_pinned_sessions,
+            commands::global_stats,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/lib/ipc";
 import { SessionList } from "@/components/session-list";
 import { SessionDetail } from "@/components/session-detail";
+import { TabBar } from "@/components/tab-bar";
+import { StatsView } from "@/components/stats-view";
 import { isMac } from "@/lib/utils";
 
 const DEFAULT_LEFT_WIDTH = 380;
@@ -21,6 +23,13 @@ export default function App() {
   const [projects, setProjects] = useState<Array<[string, number]>>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const [tab, setTab] = useState<"sessions" | "stats">("sessions");
+  // Ref so keyboard handlers can read current tab without stale closures
+  const tabRef = useRef<"sessions" | "stats">("sessions");
+  useEffect(() => {
+    tabRef.current = tab;
+  }, [tab]);
 
   const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH);
   const dragRef = useRef<{ startX: number; startW: number } | null>(null);
@@ -105,6 +114,7 @@ export default function App() {
   // Arrow-key navigation across the session list (visual order).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (tabRef.current !== "sessions") return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
       const target = e.target as HTMLElement | null;
       if (target?.isContentEditable) return;
@@ -139,13 +149,28 @@ export default function App() {
     el?.scrollIntoView({ block: "nearest" });
   }, [selectedId]);
 
-  // Shortcuts to focus and clear the search input.
+  // Shortcuts to focus and clear the search input; also handles tab switching.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const input = searchInputRef.current;
 
       const modKey = isMac() ? e.metaKey : e.ctrlKey;
+
+      // Tab switch shortcuts work on all tabs
+      if (modKey && !e.shiftKey && !e.altKey && e.key === "1") {
+        e.preventDefault();
+        setTab("sessions");
+        return;
+      }
+      if (modKey && !e.shiftKey && !e.altKey && e.key === "2") {
+        e.preventDefault();
+        setTab("stats");
+        return;
+      }
+
+      if (tabRef.current !== "sessions") return;
+
       if (modKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
         e.preventDefault();
         input?.focus();
@@ -212,37 +237,49 @@ export default function App() {
   };
 
   return (
-    <div className="flex h-screen w-screen overflow-hidden" style={{ background: "var(--surface)" }}>
-      <div style={{ width: leftWidth, flex: "0 0 auto" }}>
-        <SessionList
-          sessions={sessions}
-          pinnedSessions={pinnedSessions}
-          projects={projects}
-          selectedId={selectedId}
-          onSelect={setSelectedId}
-          query={query}
-          onQueryChange={setQuery}
-          projectFilter={projectFilter}
-          onProjectFilterChange={setProjectFilter}
-          modelFilter={modelFilter}
-          onModelFilterChange={setModelFilter}
-          loading={loading}
-          searchInputRef={searchInputRef}
-          onPinToggled={onPinToggled}
-        />
-      </div>
-      <div
-        onMouseDown={onDragStart}
-        className="w-1 cursor-col-resize"
-        style={{ background: "var(--border)" }}
-      />
-      <div className="flex-1 min-w-0">
-        <SessionDetail
-          session={selected}
-          onSessionPatched={onSessionPatched}
-          onPinToggled={onPinToggled}
-        />
-      </div>
+    <div
+      className="flex flex-col h-screen w-screen overflow-hidden"
+      style={{ background: "var(--surface)" }}
+    >
+      <TabBar tab={tab} onChange={setTab} />
+      {tab === "sessions" ? (
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          <div style={{ width: leftWidth, flex: "0 0 auto" }}>
+            <SessionList
+              sessions={sessions}
+              pinnedSessions={pinnedSessions}
+              projects={projects}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              query={query}
+              onQueryChange={setQuery}
+              projectFilter={projectFilter}
+              onProjectFilterChange={setProjectFilter}
+              modelFilter={modelFilter}
+              onModelFilterChange={setModelFilter}
+              loading={loading}
+              searchInputRef={searchInputRef}
+              onPinToggled={onPinToggled}
+            />
+          </div>
+          <div
+            onMouseDown={onDragStart}
+            className="w-1 cursor-col-resize"
+            style={{ background: "var(--border)" }}
+          />
+          <div className="flex-1 min-w-0">
+            <SessionDetail
+              session={selected}
+              onSessionPatched={onSessionPatched}
+              onPinToggled={onPinToggled}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <StatsView />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/stats-view.tsx
+++ b/src/components/stats-view.tsx
@@ -1,0 +1,355 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { type GlobalStats, type WeeklyBucket, globalStats } from "@/lib/ipc";
+import {
+  formatNumber,
+  formatCost,
+  formatRelative,
+  basename,
+} from "@/lib/utils";
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        padding: "16px 20px",
+      }}
+    >
+      <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 4 }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 600, color: "var(--text)" }}>
+        {value}
+      </div>
+      {sub !== undefined ? (
+        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4, lineHeight: 1.5 }}>
+          {sub}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const CHART_W = 600;
+const CHART_H = 100;
+
+function WeeklyChart({ data }: { data: WeeklyBucket[] }) {
+  const maxSessions = Math.max(...data.map((b) => b.sessions), 1);
+  const slotW = CHART_W / data.length;
+  const barW = Math.max(1, Math.floor(slotW) - 3);
+  const labelIndices = [0, 4, 8];
+
+  return (
+    <svg
+      viewBox={`0 0 ${CHART_W} ${CHART_H + 20}`}
+      style={{ width: "100%", height: "auto", display: "block" }}
+    >
+      {data.map((b, i) => {
+        const barH = Math.max(b.sessions > 0 ? 3 : 0, (b.sessions / maxSessions) * CHART_H);
+        const x = i * slotW;
+        const y = CHART_H - barH;
+        const dateLabel = new Date(b.week_start_ms).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        });
+        const tooltipDate = new Date(b.week_start_ms).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        });
+
+        return (
+          <g key={b.week_start_ms}>
+            <rect
+              x={x + 1}
+              y={y}
+              width={barW}
+              height={barH}
+              rx={2}
+              fill={b.sessions > 0 ? "var(--accent)" : "var(--surface-3)"}
+            >
+              <title>{`${tooltipDate} · ${b.sessions} sessions · ${formatCost(b.cost_usd)}`}</title>
+            </rect>
+            {labelIndices.includes(i) ? (
+              <text
+                x={x + slotW / 2}
+                y={CHART_H + 14}
+                fontSize={9}
+                textAnchor="middle"
+                fill="var(--text-muted)"
+              >
+                {dateLabel}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function TopList({ title, items }: { title: string; items: [string, number][] }) {
+  const max = items[0]?.[1] ?? 1;
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: "var(--text-muted)",
+          marginBottom: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {items.length === 0 ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 13 }}>—</div>
+        ) : (
+          items.map(([name, count]) => (
+            <div key={name}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                  fontSize: 13,
+                }}
+              >
+                <span
+                  title={name}
+                  style={{
+                    color: "var(--text)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    maxWidth: "82%",
+                  }}
+                >
+                  {basename(name) || name}
+                </span>
+                <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>
+                  {count}
+                </span>
+              </div>
+              <div
+                style={{
+                  height: 3,
+                  background: "var(--surface-3)",
+                  borderRadius: 2,
+                }}
+              >
+                <div
+                  style={{
+                    height: 3,
+                    background: "var(--accent)",
+                    borderRadius: 2,
+                    width: `${((count / max) * 100).toFixed(0)}%`,
+                  }}
+                />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function StatsView() {
+  const [stats, setStats] = useState<GlobalStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    globalStats()
+      .then((s) => {
+        setStats(s);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const un = listen("sessions-updated", () => {
+      globalStats().then(setStats).catch(() => {});
+    });
+    return () => {
+      un.then((fn) => fn());
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          color: "var(--text-muted)",
+          fontSize: 13,
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (stats === null || stats.total_sessions === 0) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          color: "var(--text-muted)",
+          fontSize: 13,
+        }}
+      >
+        No sessions indexed yet.
+      </div>
+    );
+  }
+
+  // Derived during render — no effect needed
+  const cacheHitRate =
+    stats.total_input_tokens > 0
+      ? `${((stats.total_cache_read_tokens / stats.total_input_tokens) * 100).toFixed(1)}%`
+      : null;
+
+  const allEmpty = stats.weekly_activity.every((b) => b.sessions === 0);
+
+  const firstDate =
+    stats.first_session_ms !== null
+      ? new Date(stats.first_session_ms).toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })
+      : "—";
+
+  const lastRelative =
+    stats.last_session_ms !== null ? formatRelative(stats.last_session_ms) : "—";
+
+  return (
+    <div style={{ overflowY: "auto", height: "100%", padding: "24px 0" }}>
+      <div
+        style={{
+          maxWidth: 880,
+          margin: "0 auto",
+          padding: "0 24px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 28,
+        }}
+      >
+        {/* Totals */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: 12,
+          }}
+        >
+          <StatCard label="Sessions" value={formatNumber(stats.total_sessions)} />
+          <StatCard
+            label="Messages"
+            value={formatNumber(stats.total_messages)}
+            sub={`${formatNumber(stats.total_user_messages)} user · ${formatNumber(stats.total_assistant_messages)} assistant`}
+          />
+          <StatCard label="Est. API Cost" value={formatCost(stats.total_cost_usd)} />
+          <StatCard
+            label="Tokens"
+            value={formatNumber(stats.total_input_tokens + stats.total_output_tokens)}
+            sub={
+              <>
+                {formatNumber(stats.total_input_tokens)} in ·{" "}
+                {formatNumber(stats.total_output_tokens)} out
+                {stats.total_cache_read_tokens > 0 ? (
+                  <> · {formatNumber(stats.total_cache_read_tokens)} cached</>
+                ) : null}
+                {cacheHitRate !== null ? (
+                  <> · {cacheHitRate} cache hits</>
+                ) : null}
+              </>
+            }
+          />
+        </div>
+
+        {/* Activity row */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: 12,
+          }}
+        >
+          <StatCard
+            label="This week"
+            value={formatNumber(stats.sessions_this_week)}
+          />
+          <StatCard
+            label="Today (UTC)"
+            value={formatNumber(stats.sessions_today)}
+          />
+          <StatCard label="First session" value={firstDate} />
+          <StatCard label="Most recent" value={lastRelative} />
+        </div>
+
+        {/* Weekly chart */}
+        <div>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--text)",
+              marginBottom: 12,
+            }}
+          >
+            Weekly activity — last 12 weeks
+          </div>
+          {allEmpty ? (
+            <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
+              No sessions in the last 12 weeks.
+            </div>
+          ) : (
+            <WeeklyChart data={stats.weekly_activity} />
+          )}
+        </div>
+
+        {/* Top projects / models */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
+          <TopList title="Top projects" items={stats.top_projects} />
+          <TopList title="Top models" items={stats.top_models} />
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            borderTop: "1px solid var(--border)",
+            paddingTop: 12,
+          }}
+        >
+          Est. API cost is hypothetical — Max-subscription users don't actually pay this.
+          Week boundaries and "Today" use UTC.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -1,0 +1,41 @@
+import { isMac } from "@/lib/utils";
+
+interface TabBarProps {
+  tab: "sessions" | "stats";
+  onChange: (t: "sessions" | "stats") => void;
+}
+
+export function TabBar({ tab, onChange }: TabBarProps) {
+  const mod = isMac() ? "⌘" : "Ctrl+";
+  return (
+    <div
+      className="flex gap-1 px-3 py-2 flex-shrink-0"
+      style={{
+        background: "var(--surface-2)",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      {(["sessions", "stats"] as const).map((t, i) => (
+        <button
+          key={t}
+          onClick={() => onChange(t)}
+          style={{
+            background: tab === t ? "var(--accent)" : "var(--surface-3)",
+            color: tab === t ? "#fff" : "var(--text)",
+            border: "none",
+            borderRadius: 6,
+            padding: "4px 12px",
+            cursor: "pointer",
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          {t === "sessions" ? "Sessions" : "Stats"}
+          <span style={{ marginLeft: 6, opacity: 0.5, fontSize: 11 }}>
+            {mod}{i + 1}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -105,3 +105,31 @@ export async function setSessionPinned(sessionId: string, pinned: boolean): Prom
 export async function listPinnedSessions(): Promise<SessionRow[]> {
   return invoke<SessionRow[]>("list_pinned_sessions");
 }
+
+export interface WeeklyBucket {
+  week_start_ms: number;
+  sessions: number;
+  messages: number;
+  cost_usd: number;
+}
+
+export interface GlobalStats {
+  total_sessions: number;
+  total_messages: number;
+  total_user_messages: number;
+  total_assistant_messages: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_read_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cost_usd: number;
+  sessions_today: number;
+  sessions_this_week: number;
+  first_session_ms: number | null;
+  last_session_ms: number | null;
+  top_projects: [string, number][];
+  top_models: [string, number][];
+  weekly_activity: WeeklyBucket[];
+}
+
+export const globalStats = (): Promise<GlobalStats> => invoke<GlobalStats>("global_stats");


### PR DESCRIPTION
## Summary

- Adds a **Stats tab** (⌘2 / Ctrl+2) — dedicated view for aggregate metrics, keeping the session browser clean
- **Totals grid**: sessions, messages, est. API cost, tokens with cache hit rate
- **Activity row**: this week, today (UTC), first session date, most recent (relative)
- **Weekly chart**: hand-rolled SVG bar chart for the last 12 weeks with native tooltips
- **Top 5 projects / models** with proportional count bars; projects show `basename()` with full path in `title`

Key implementation notes:
- `top_models` uses `json_each(models_used_json)` in SQL — no row-fetching to Rust
- Weekly buckets use a SQL CTE with integer day arithmetic → Monday-midnight-UTC epoch-ms; Rust only zero-fills 12 slots
- Keyboard guards use a `tabRef` synced via effect to avoid stale closures
- UTC used consistently for "today" cutoff and weekly buckets

## Test plan

- [ ] `cargo check` / `cargo clippy` / `bun run tsc --noEmit` all pass clean
- [ ] Sessions tab and two-pane layout are unchanged
- [ ] ⌘2 opens Stats; ⌘1 returns to Sessions
- [ ] Stats totals match sidebar session count
- [ ] Cache hit rate shows a plausible percentage
- [ ] Weekly chart: 12 bars, current week rightmost
- [ ] Top projects shows basenames, not full paths
- [ ] Arrow keys / `/` / ⌘K do nothing on Stats tab
- [ ] New session in another terminal → Stats auto-refreshes within ~2s
- [ ] Dark mode respected throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)