### PR TITLE
feat: background AI TLDR generation with ready notification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import {
+  generateSummary,
   listPinnedSessions,
   listProjects,
   listSessions,
@@ -10,6 +11,7 @@ import { SessionList } from "@/components/session-list";
 import { SessionDetail } from "@/components/session-detail";
 import { TabBar } from "@/components/tab-bar";
 import { StatsView } from "@/components/stats-view";
+import { TldrReadyBanner } from "@/components/tldr-ready-banner";
 import { isMac } from "@/lib/utils";
 
 const DEFAULT_LEFT_WIDTH = 380;
@@ -23,6 +25,19 @@ export default function App() {
   const [projects, setProjects] = useState<Array<[string, number]>>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Background TLDR generation state. Lives at the App level so the in-flight
+  // state survives navigation and the completion handler can patch the correct
+  // session by ID (not by stale closure).
+  const [pendingTldrs, setPendingTldrs] = useState<Set<string>>(new Set());
+  const [tldrErrors, setTldrErrors] = useState<Map<string, string>>(new Map());
+  const [tldrReady, setTldrReady] = useState<
+    { sessionId: string; title: string } | null
+  >(null);
+  const selectedIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    selectedIdRef.current = selectedId;
+  }, [selectedId]);
 
   const [tab, setTab] = useState<"sessions" | "stats">("sessions");
   // Ref so keyboard handlers can read current tab without stale closures
@@ -203,13 +218,59 @@ export default function App() {
     return () => window.removeEventListener("keydown", handler);
   }, [query]);
 
-  const onSessionPatched = useCallback((patched: SessionRow) => {
-    setSessions((rows) =>
-      rows.map((r) => (r.session_id === patched.session_id ? patched : r))
-    );
-    setPinnedSessions((rows) =>
-      rows.map((r) => (r.session_id === patched.session_id ? patched : r))
-    );
+  const generateTldr = useCallback(
+    async (sessionId: string, title: string) => {
+      setPendingTldrs((s) => {
+        if (s.has(sessionId)) return s;
+        const n = new Set(s);
+        n.add(sessionId);
+        return n;
+      });
+      setTldrErrors((m) => {
+        if (!m.has(sessionId)) return m;
+        const n = new Map(m);
+        n.delete(sessionId);
+        return n;
+      });
+      try {
+        const summary = await generateSummary(sessionId);
+        setSessions((rows) =>
+          rows.map((r) =>
+            r.session_id === sessionId ? { ...r, ai_summary: summary } : r
+          )
+        );
+        setPinnedSessions((rows) =>
+          rows.map((r) =>
+            r.session_id === sessionId ? { ...r, ai_summary: summary } : r
+          )
+        );
+        if (selectedIdRef.current !== sessionId) {
+          setTldrReady({ sessionId, title });
+        }
+      } catch (e) {
+        setTldrErrors((m) => {
+          const n = new Map(m);
+          n.set(sessionId, String(e));
+          return n;
+        });
+      } finally {
+        setPendingTldrs((s) => {
+          if (!s.has(sessionId)) return s;
+          const n = new Set(s);
+          n.delete(sessionId);
+          return n;
+        });
+      }
+    },
+    []
+  );
+
+  const dismissTldrReady = useCallback(() => setTldrReady(null), []);
+  const jumpToTldrReady = useCallback(() => {
+    setTldrReady((ready) => {
+      if (ready) setSelectedId(ready.sessionId);
+      return null;
+    });
   }, []);
 
   const onPinToggled = useCallback(() => {
@@ -260,6 +321,7 @@ export default function App() {
               loading={loading}
               searchInputRef={searchInputRef}
               onPinToggled={onPinToggled}
+              pendingTldrs={pendingTldrs}
             />
           </div>
           <div
@@ -270,8 +332,10 @@ export default function App() {
           <div className="flex-1 min-w-0">
             <SessionDetail
               session={selected}
-              onSessionPatched={onSessionPatched}
               onPinToggled={onPinToggled}
+              pendingTldrs={pendingTldrs}
+              tldrErrors={tldrErrors}
+              onGenerateTldr={generateTldr}
             />
           </div>
         </div>
@@ -279,6 +343,13 @@ export default function App() {
         <div className="flex-1 min-h-0 overflow-hidden">
           <StatsView />
         </div>
+      )}
+      {tldrReady && tldrReady.sessionId !== selectedId && (
+        <TldrReadyBanner
+          title={tldrReady.title}
+          onJump={jumpToTldrReady}
+          onDismiss={dismissTldrReady}
+        />
       )}
     </div>
   );

--- a/src/components/session-detail.tsx
+++ b/src/components/session-detail.tsx
@@ -5,7 +5,6 @@ import { Star } from "lucide-react";
 import {
   copyResumeCommand,
   exportMarkdown,
-  generateSummary,
   getTranscript,
   saveMarkdownToDisk,
   setSessionPinned,
@@ -24,8 +23,10 @@ import { Transcript } from "./transcript";
 
 interface Props {
   session: SessionRow | null;
-  onSessionPatched: (s: SessionRow) => void;
   onPinToggled: () => void;
+  pendingTldrs: Set<string>;
+  tldrErrors: Map<string, string>;
+  onGenerateTldr: (sessionId: string, title: string) => void;
 }
 
 function heuristicTldr(s: SessionRow): string {
@@ -34,16 +35,22 @@ function heuristicTldr(s: SessionRow): string {
   return "(no user prompts in this session)";
 }
 
-export function SessionDetail({ session, onSessionPatched, onPinToggled }: Props) {
+export function SessionDetail({
+  session,
+  onPinToggled,
+  pendingTldrs,
+  tldrErrors,
+  onGenerateTldr,
+}: Props) {
   const [turns, setTurns] = useState<Turn[]>([]);
-  const [summaryBusy, setSummaryBusy] = useState(false);
-  const [summaryError, setSummaryError] = useState<string | null>(null);
   const [resumeCopied, setResumeCopied] = useState(false);
   const [exportStatus, setExportStatus] = useState<string | null>(null);
 
+  const summaryBusy = session ? pendingTldrs.has(session.session_id) : false;
+  const summaryError = session ? tldrErrors.get(session.session_id) ?? null : null;
+
   useEffect(() => {
     setTurns([]);
-    setSummaryError(null);
     setResumeCopied(false);
     setExportStatus(null);
     if (!session) return;
@@ -78,19 +85,14 @@ export function SessionDetail({ session, onSessionPatched, onPinToggled }: Props
     setTimeout(() => setResumeCopied(false), 2000);
   }, [session?.session_id]);
 
-  const onGenerateSummary = useCallback(async () => {
+  const onGenerateSummary = useCallback(() => {
     if (!session) return;
-    setSummaryBusy(true);
-    setSummaryError(null);
-    try {
-      const summary = await generateSummary(session.session_id);
-      onSessionPatched({ ...session, ai_summary: summary });
-    } catch (e) {
-      setSummaryError(String(e));
-    } finally {
-      setSummaryBusy(false);
-    }
-  }, [session, onSessionPatched]);
+    const title =
+      session.custom_title ||
+      session.first_user_msg?.split("\n")[0]?.slice(0, 120) ||
+      `Session ${session.session_id.slice(0, 8)}`;
+    onGenerateTldr(session.session_id, title);
+  }, [session, onGenerateTldr]);
 
   const onExport = useCallback(async () => {
     if (!session) return;

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type Ref } from "react";
-import { Star } from "lucide-react";
+import { Loader2, Star } from "lucide-react";
 import { setSessionPinned, type SessionRow } from "@/lib/ipc";
 import {
   cn,
@@ -23,6 +23,7 @@ interface Props {
   loading: boolean;
   searchInputRef?: Ref<HTMLInputElement>;
   onPinToggled: () => void;
+  pendingTldrs: Set<string>;
 }
 
 function stripCaveat(raw: string): string {
@@ -91,6 +92,7 @@ export function SessionList(props: Props) {
     const uniqueModels = Array.from(new Set(models));
     const isSelected = s.session_id === props.selectedId;
     const isPinned = s.pinned_at !== null;
+    const isGeneratingTldr = props.pendingTldrs.has(s.session_id);
     return (
       <div
         key={s.session_id}
@@ -150,6 +152,17 @@ export function SessionList(props: Props) {
             )}
             {s.has_errors && (
               <span style={{ color: "var(--danger)" }}>· errors</span>
+            )}
+            {isGeneratingTldr && (
+              <span
+                className="inline-flex items-center gap-1"
+                style={{ color: "var(--accent)" }}
+                title="Generating TLDR…"
+                aria-label="Generating TLDR"
+              >
+                <span aria-hidden="true">·</span>
+                <Loader2 size={11} className="animate-spin" strokeWidth={2} />
+              </span>
             )}
           </div>
         </button>

--- a/src/components/tldr-ready-banner.tsx
+++ b/src/components/tldr-ready-banner.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { X } from "lucide-react";
+
+interface Props {
+  title: string;
+  onJump: () => void;
+  onDismiss: () => void;
+}
+
+const AUTO_DISMISS_MS = 10000;
+
+export function TldrReadyBanner({ title, onJump, onDismiss }: Props) {
+  useEffect(() => {
+    const t = setTimeout(onDismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-50 flex max-w-sm items-start gap-3 rounded-lg border px-4 py-3 shadow-lg"
+      style={{
+        background: "var(--surface-2)",
+        borderColor: "var(--border)",
+        color: "var(--text)",
+      }}
+    >
+      <div className="min-w-0 flex-1">
+        <div
+          className="mb-0.5 text-[10.5px] font-semibold uppercase tracking-[0.08em]"
+          style={{ color: "var(--accent)" }}
+        >
+          TLDR ready
+        </div>
+        <div className="truncate text-sm" title={title}>
+          {title}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          onClick={onJump}
+          className="rounded-md px-2.5 py-1 text-xs font-medium"
+          style={{ background: "var(--accent)", color: "white" }}
+        >
+          Jump
+        </button>
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className="rounded-md p-1"
+          style={{ color: "var(--text-muted)" }}
+        >
+          <X size={14} strokeWidth={1.75} />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Lift AI TLDR generation state from `SessionDetail` local state into `App.tsx` so you can browse other chats while one is generating.
- Add a spinning badge on the originating session row in the left pane so you always know what's cooking.
- Add a floating "TLDR ready — Jump" banner (bottom-right, auto-dismisses after 10s) that appears when generation completes on a session you're not currently viewing, with a one-click return.
- Fix a latent bug where navigating away mid-generation could patch the wrong session's in-memory state — the completion handler now keys on the session ID passed into the call and reads current selection via a ref.

## Test plan
- [ ] Click "Generate AI TLDR" on session A; spinner appears on A's row and "Generating…" shows in the detail pane.
- [ ] Switch to session B while A is generating; B loads normally, A's row still shows the spinner.
- [ ] Kick off TLDR on B too; both rows show spinners simultaneously.
- [ ] When A completes while viewing B, bottom-right banner appears with A's title and a Jump button; clicking Jump selects A and shows the summary.
- [ ] Dismiss (×) on the banner hides it; banner also auto-dismisses after ~10s.
- [ ] Navigate *to* A while A is still generating; when it finishes, no banner appears (you're already there) and the summary renders inline.
- [ ] Start TLDR on A, rapidly switch A → B → C; when A completes, only A has `ai_summary`, B and C are untouched.
- [ ] Force an error (e.g. break the `claude` path): spinner stops, error text appears in A's detail pane, no banner, other sessions unaffected.
- [ ] `bun run tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)