### PR TITLE
fix: stop sort dropdown from getting clipped at narrow panel widths

### DIFF
--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -216,7 +216,7 @@ export function SessionList(props: Props) {
           <select
             value={props.projectFilter ?? ""}
             onChange={(e) => props.onProjectFilterChange(e.target.value || null)}
-            className="flex-1 rounded-md px-2 py-1 outline-none"
+            className="min-w-0 flex-1 rounded-md px-2 py-1 outline-none"
             style={{
               background: "var(--surface)",
               color: "var(--text)",
@@ -247,24 +247,25 @@ export function SessionList(props: Props) {
               </option>
             ))}
           </select>
-          <select
-            value={props.sortBy}
-            onChange={(e) => props.onSortByChange(e.target.value as SortKey)}
-            className="rounded-md px-2 py-1 outline-none"
-            style={{
-              background: "var(--surface)",
-              color: "var(--text)",
-              border: "1px solid var(--border)",
-            }}
-            title="Sort sessions"
-          >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={opt.key} value={opt.key}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
         </div>
+        <select
+          value={props.sortBy}
+          onChange={(e) => props.onSortByChange(e.target.value as SortKey)}
+          className="w-full rounded-md px-2 py-1 text-xs outline-none"
+          style={{
+            background: "var(--surface)",
+            color: "var(--text)",
+            border: "1px solid var(--border)",
+          }}
+          title="Sort sessions"
+          aria-label="Sort sessions"
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.key} value={opt.key}>
+              Sort: {opt.label}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
## Summary
- Three selects in one row (projects + models + sort) overflowed a ~400px sidebar — sort got clipped.
- Move sort to its own full-width row below the filters. Options now read "Sort: Newest first" etc. so the standalone trigger label is self-explanatory.
- Add \`min-w-0\` to the projects select so it can shrink when "All projects (105)" is selected — previously it ate all available row width.

## Test plan
- [ ] Launch at default sidebar width; all three controls visible, nothing clipped.
- [ ] Drag the splitter to minimum width (260px); sort still readable on its own row.
- [ ] Change sort; session order updates as before.
- [ ] Projects and models dropdowns still work on row 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)